### PR TITLE
Use identical export for priority types

### DIFF
--- a/priority.d.ts
+++ b/priority.d.ts
@@ -1,4 +1,4 @@
 type isDone = () => void;
 type toAdd = (fn: Function, isHigh?: boolean) => void;
 declare function throttles(limit?: number): [toAdd, isDone];
-export default throttles;
+export = throttles;


### PR DESCRIPTION
Thanks for creating this little gem of a library!

When implementing this in a TypeScript project, we've been getting an error about a missing call signature for `throttles/priority`. The compiler had problems merging the two existing declarations from `/priority.d.ts` and `index.d.ts`.

The fix is rather simple: just make both declarations identical in how they declare the default export.

**Before**

<img width="807" alt="Screenshot 2023-08-14 at 22 16 30" src="https://github.com/lukeed/throttles/assets/22225348/81203047-48f5-4930-a989-bc0cf57235f2">

**After**

<img width="711" alt="Screenshot 2023-08-14 at 22 16 54" src="https://github.com/lukeed/throttles/assets/22225348/28bf196a-1391-4406-b81f-ca74f23a719f">
